### PR TITLE
Replace export which breaks jest (Issue #27)

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,4 +57,6 @@ const useStore = (React, initialState, actions, initializer) => {
   return useCustom.bind(null, store, React);
 };
 
-export default useStore;
+// fix for issue #27
+// export default useStore;
+module.exports = useStore;


### PR DESCRIPTION
The `export default useStore` statement breaks jest, as reported in issue #27. Several people gave the correct solution to the problem in the issue, which is to use `module.exports = useStore` instead.