### PR TITLE
Reset State

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function useCustom(store, React, mapState, mapActions) {
       store.listeners = store.listeners.filter(
         listener => listener !== newListener
       );
+      store.state = store.listeners.length <= 0 ? initialState : store.state
     };
   }, []); // eslint-disable-line
   return [state, actions];


### PR DESCRIPTION
When an entire route and its components are no longer using that **GlobalState**, we reset the entire state to the **initialState**.
Based on the principle of **SOLID**, React Navigation is the one who must transfer PROPS when there is a need to exchange information between routes.


When an entire globalState instance is active and its components are using the same state, it will not be reset unless it **DISMONTS** its entire component and route.
With that we leave all the work for globalState to do.
If they see the need not to reset the state, they can persist in dismounting the component itself.