### PR TITLE
Fixing Reset State

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+
 function setState(store, newState, afterUpdateCallback) {
   store.state = { ...store.state, ...newState };
   store.listeners.forEach((listener) => {
@@ -6,7 +7,7 @@ function setState(store, newState, afterUpdateCallback) {
   afterUpdateCallback && afterUpdateCallback();
 }
 
-function useCustom(store, React, mapState, mapActions) {
+function useCustom(store, React, initialState, mapState, mapActions) {
   const [, originalHook] = React.useState(Object.create(null));
   const state = mapState ? mapState(store.state) : store.state;
   const actions = React.useMemo(
@@ -18,12 +19,12 @@ function useCustom(store, React, mapState, mapActions) {
     const newListener = { oldState: {} };
     newListener.run = mapState
       ? newState => {
-          const mappedState = mapState(newState);
-          if (mappedState !== newListener.oldState) {
-            newListener.oldState = mappedState;
-            originalHook(mappedState);
-          }
+        const mappedState = mapState(newState);
+        if (mappedState !== newListener.oldState) {
+          newListener.oldState = mappedState;
+          originalHook(mappedState);
         }
+      }
       : originalHook;
     store.listeners.push(newListener);
     newListener.run(store.state);
@@ -55,7 +56,7 @@ const useStore = (React, initialState, actions, initializer) => {
   store.setState = setState.bind(null, store);
   store.actions = associateActions(store, actions);
   if (initializer) initializer(store);
-  return useCustom.bind(null, store, React);
+  return useCustom.bind(null, store, React, initialState);
 };
 
 export default useStore;

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function useCustom(store, React, mapState, mapActions) {
       store.listeners = store.listeners.filter(
         listener => listener !== newListener
       );
+      store.state = store.listeners.length <= 0 ? initialState : store.state
     };
   }, []); // eslint-disable-line
   return [state, actions];

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function setState(store, newState, afterUpdateCallback) {
   afterUpdateCallback && afterUpdateCallback();
 }
 
-function useCustom(store, React, initialState, mapState, mapActions) {
+function useCustom(store, React, mapState, mapActions) {
   const [, originalHook] = React.useState(Object.create(null));
   const state = mapState ? mapState(store.state) : store.state;
   const actions = React.useMemo(


### PR DESCRIPTION
*I had forgotten a small part of the code*

When an entire route and its components are no longer using that GlobalState, we reset the entire state to the initialState.
Based on the principle of SOLID, React Navigation is the one who must transfer PROPS when there is a need to exchange information between routes.


When an entire globalState instance is active and its components are using the same state, it will not be reset unless it DISMONTS its entire component and route.
With that we leave all the work for globalState to do.
If they see the need not to reset the state, they can persist in dismounting the component itself.