### PR TITLE
Add edge support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 function setState(store, newState, afterUpdateCallback) {
-  store.state = { ...store.state, ...newState };
+  store.state = Object.assign(store.state, newState);
   store.listeners.forEach((listener) => {
     listener.run(store.state);
   });


### PR DESCRIPTION
Hi @andregardi 

As of you are not doing any transpilation I decided just do a small change in your code which is breaking support for ALL the Edge versions. 
You can see in [MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Browser_compatibility) that Spread in object literals is not supported in Edge browser. But as you can see [Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Browser_compatibility) is supported from Edge 12.