### PR TITLE
Type field for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "main": "index.js",
   "name": "use-global-hook",
   "repository": "github:andregardi/use-global-hook",
+  "type":"module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.1.12",
+  "version": "0.1.13",
   "author": "andregardi"
 }


### PR DESCRIPTION
Fix #27 for those who are using node version >= 13
Also is related to PR https://github.com/andregardi/use-global-hook/pull/32

More info about this
https://nodejs.org/api/esm.html#esm_package_json_type_field