### PR TITLE
Fix 4 issues with newListenerEffect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 .env.test
 
 build/
+nohup.out

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#DEPRECATED
+# DEPRECATED
 
 This is no longer supported, please use https://github.com/qosenergy/shared-store-hook instead.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+This is no longer supported, please use https://github.com/qosenergy/shared-store-hook instead.
+
+
 # use-global-hook
 
 Easy state management for react using hooks in less than 1kb.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
 # DEPRECATED
 
 This is no longer supported, please use https://github.com/qosenergy/shared-store-hook instead.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+#DEPRECATED
 
 This is no longer supported, please use https://github.com/qosenergy/shared-store-hook instead.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-terser": "^7.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^17.0.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/src/core/customHook.js
+++ b/src/core/customHook.js
@@ -12,7 +12,7 @@ export function customHook(store, React, mapState, mapActions) {
 
   const originalHook = React.useState(Object.create(null))[1];
 
-  React.useEffect(newListenerEffect(store, mapState, originalHook), []); // eslint-disable-line
+  React.useEffect(newListenerEffect(store, mapState, originalHook, state), []); // eslint-disable-line
 
   return [state, actions];
 }

--- a/src/core/newListenerEffect.js
+++ b/src/core/newListenerEffect.js
@@ -1,9 +1,14 @@
 import { cleanUpListener } from "./cleanUpListener";
 
-export const newListenerEffect = (store, mapState, originalHook) => () => {
+export const newListenerEffect = (
+  store,
+  mapState,
+  originalHook,
+  initialMappedState
+) => () => {
   const newListener = {
     isComponentBeingUnmounted: false,
-    oldState: undefined,
+    oldState: initialMappedState,
   };
   newListener.run = (newState) => {
     if (newListener.isComponentBeingUnmounted) {

--- a/src/core/newListenerEffect.js
+++ b/src/core/newListenerEffect.js
@@ -3,7 +3,7 @@ import { cleanUpListener } from "./cleanUpListener";
 export const newListenerEffect = (store, mapState, originalHook) => () => {
   const newListener = {
     isComponentBeingUnmounted: false,
-    oldState: {},
+    oldState: undefined,
   };
   newListener.run = (newState) => {
     if (newListener.isComponentBeingUnmounted) {

--- a/src/core/newListenerEffect.js
+++ b/src/core/newListenerEffect.js
@@ -1,16 +1,25 @@
 import { cleanUpListener } from "./cleanUpListener";
 
 export const newListenerEffect = (store, mapState, originalHook) => () => {
-  const newListener = { oldState: {} };
-  newListener.run = mapState
-    ? (newState) => {
-        const mappedState = mapState(newState);
-        if (mappedState !== newListener.oldState) {
-          newListener.oldState = mappedState;
-          originalHook(mappedState);
-        }
-      }
-    : originalHook;
+  const newListener = {
+    isComponentBeingUnmounted: false,
+    oldState: {},
+  };
+  newListener.run = (newState) => {
+    if (newListener.isComponentBeingUnmounted) {
+      return;
+    }
+    const mappedState = mapState ? mapState(newState) : newState;
+    if (mappedState === newListener.oldState) {
+      return;
+    }
+    newListener.oldState = mappedState;
+    // call the original hook with a new reference to trigger a re-render
+    originalHook(Object.create(null));
+  };
   store.listeners.push(newListener);
-  return cleanUpListener(store, newListener);
+  return () => {
+    newListener.isComponentBeingUnmounted = true;
+    cleanUpListener(store, newListener)();
+  };
 };


### PR DESCRIPTION
Fix 4 issues with newListenerEffect:

1. As per issue #40, React warnings "Can't perform a React state update on an
   unmounted component" were triggered when the originalHook() calls occurred
   while the component was in the process of being unmounted.

   The useEffect cleanup method now sets up a flag that is tested in the run()
   calls to prevent this.

2. originalHook() needs to be called with a different reference value every
   time, to ensure React will re-render the component.

   When it was called with an argument of mappedState, in the code before this
   PR, it actually worked because mappedState was a different reference every
   time, but the actual *contents* of mappedState did not matter: this is
   *not* the state returned by the hook, which is set in setState.js.
   Calling originalHook(mappedState) was therefore confusing and has been
   replaced with originalHook(Object.create(null)) with a comment.

   When no mapState function was provided and originalHook was called with no
   argument, depending on how the use-global-hook code was called (eg. by not
   object-destructuring the state), this could result in React *not*
   re-rendering the component at all, despite the state change: the state that
   was changed was *not* the one created with React.useState in customHook.js,
   so as *that* reference was identical, no re-render was triggered.

   To fix this, originalHook is now always called as :

   originalHook(Object.create(null));

   whether a mapState function was provided or not.

   The check to call originalHook depending on whether the state has actually
   changed or not is now used when no mapState was provided as well, to make for
   a more consistent behaviour.
   
3. If a component only wishes to use one or several of the store's *actions*,
    but is not going to use any part of the *state*, this component should
    *not* be re-rendered when the state changes.
    
    This should be possible by providing a `mapState` function which return
    value would always match `newListener.oldState`.
    
    But `oldState` is initialized with an anonymous object reference
    (`oldState: {}`) which can not be compared against.
    
    Providing a `mapState` function of:
    
    `(state) => ({})`
    
    would not work as the two references are not equal, and the test on line
    13 (`if (mappedState === newListener.oldState)`) would fail.
    
    For this test to succeed, and therefore for actions-only components not
    to be re-rendered on each state change, the initial `oldState` must be
    equal to each return value from `mapState`. This commit changes the
    initial value of `oldState` to `undefined`, so that any component can
    write something like :
    
    `const [, { actionOne, actionTwo }] = useXyz(() => undefined);`
    
    and never be re-rendered on state changes, while still having access to
    actions.

4. `newListener.run` is called on each state update. It calls the
    `originalHook` to re-render the component if it detects that the new
    mapped state's value - either a discrete value or an object reference -
    differs from the previously stored one.

    This works fine for the second update and up, but for the *first*
    update, the new mapped state will be compared to the *initial* value
    of `newListener.oldState`, which was `{}` and has been changed to
    `undefined` above.

    This means that, unless the `mapState` function returns `undefined`
    (to indicate the caller doesn't wish to subscribe to the state, but
    only use actions), the first update to the state will *always*
    re-render all the state subscribers, as the mapped state after the
    update will differ from `undefined`.

    To prevent this, `newListener.oldState` is now set to the initial mapped
    state - which is the initial state if no `mapState` function was provided.

    This fix is still backward compatible and does not require any change
    to the caller code: the actions-only subscribers can still provide a
    `mapState` function that returns `undefined`. The `mapState` functions
    for actions-only subscribers can now actually return any value that
    doesn't change between renders (`undefined` or any other constant).