### PR TITLE
Add React 17 into peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-terser": "^7.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
Hey @andregardi ,

This small change will remove warnings on install for those projects that are using React 17.

I have checked and seems like you are using several methods from React which were not have had any breaking (maybe even non breaking) changes.

Cheers. ;)