### PR TITLE
fix: avoid unnecessary rendering on first state update

### DIFF
--- a/src/core/newListenerEffect.js
+++ b/src/core/newListenerEffect.js
@@ -11,6 +11,7 @@ export const newListenerEffect = (store, mapState, originalHook) => () => {
         }
       }
     : originalHook;
+  newListener.run(store.state);
   store.listeners.push(newListener);
   return cleanUpListener(store, newListener);
 };


### PR DESCRIPTION
This PR introduces fix of [this issue](https://github.com/use-global-hook/use-global-hook/issues/63)