### PR TITLE
Add redux dev tools plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Table of Contents
 * [Example](#minimal-example)
 * [Complete Examples](#complete-examples)
 * [Using TypeScript](#using-typescript)
+* [Using Redux Dev Tools](#using-redux-dev-tools)
 
 ### Install:
 
@@ -170,3 +171,31 @@ const [state, actions] = useGlobal(); // returns [unknown, unknown]
 
 // Happy TypeScripting!
 ```
+
+------------
+
+### Using Redux Dev Tools
+
+A special option `reduxDevTools` should be passed to turn on redux dev tools:
+```
+const useGlobal = globalHook(initialState, actions, { reduxDevTools: true });
+```
+or
+```
+const useGlobal = globalHook(React, initialState, actions, {
+  reduxDevTools: {
+    features: {
+      pause: true, // start/pause recording of dispatched actions
+      lock: true, // lock/unlock dispatching actions and side effects
+      export: true, // export history of actions in a file
+      import: 'custom', // import history of actions from a file
+      jump: true, // jump back and forth (time travelling)
+
+      ...other features
+    }
+    ...other options
+  }
+});
+```
+
+`reduxDevTools` property receive any valid options from official [redux dev tools docs](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md)

--- a/src/core/customHook.js
+++ b/src/core/customHook.js
@@ -14,5 +14,8 @@ export function customHook(store, React, mapState, mapActions) {
 
   React.useEffect(newListenerEffect(store, mapState, originalHook), []); // eslint-disable-line
 
+  // allow plugins to define theirs hooks
+  store.plugins.hooks.forEach(hook => hook(React));
+
   return [state, actions];
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -5,7 +5,7 @@ import { runListeners } from "./runListeners";
 import { setupOptions } from "./setupOptions";
 
 const useStore = (React, initialState, actions, options) => {
-  const store = { state: initialState, listeners: [] };
+  const store = { state: initialState, listeners: [], plugins: { hooks: [] } };
   store.setState = setState.bind(null, store);
   store.runListeners = runListeners.bind(null, store);
   store.actions = associateActions(store, actions);

--- a/src/core/setupOptions.js
+++ b/src/core/setupOptions.js
@@ -1,4 +1,5 @@
 import { immerPlugin } from "../plugins/immer";
+import { reduxDevToolsPlugin } from "../plugins/reduxDevTools";
 
 export const setupOptions = (store, options = {}) => {
   //Backward compatibility with 0.1.2
@@ -6,7 +7,8 @@ export const setupOptions = (store, options = {}) => {
     options(store);
     return;
   }
-  const { Immer, initializer } = options;
+  const { Immer, initializer, reduxDevTools } = options;
   Immer && immerPlugin(Immer, store);
+  reduxDevTools && reduxDevToolsPlugin(store, reduxDevTools);
   initializer && initializer(store);
 };

--- a/src/plugins/reduxDevTools/connectDevTools.js
+++ b/src/plugins/reduxDevTools/connectDevTools.js
@@ -1,0 +1,42 @@
+// can be only one for entire window
+let devToolsConnector;
+
+const defaultOptions = {
+  features: {
+    pause: true, // start/pause recording of dispatched actions
+    lock: true, // lock/unlock dispatching actions and side effects
+    export: true, // export history of actions in a file
+    import: 'custom', // import history of actions from a file
+    jump: true, // jump back and forth (time travelling)
+
+    skip: false, // Cannot skip for we cannot replay.
+    reorder: false, // Cannot skip for we cannot replay.
+    persist: false, // Avoid trying persistence.
+    dispatch: false,
+    test: false,
+  }
+}
+
+const devToolsAvailable = typeof window === 'object'
+  && !!window.__REDUX_DEVTOOLS_EXTENSION__;
+
+const isObject = (value) => Object.prototype.toString.call(value).slice(8, -1) === 'Object';
+
+export const connectDevTools = (options) => {
+  if (!devToolsAvailable || !options) {
+    return;
+  }
+
+  const mergedOptions = !isObject(options) ? defaultOptions : {
+    ...options,
+    features: {
+      ...defaultOptions.features,
+      ...options.features,
+    }
+  };
+
+  devToolsConnector = devToolsConnector
+    || window.__REDUX_DEVTOOLS_EXTENSION__.connect(mergedOptions);
+
+  return devToolsConnector;
+};

--- a/src/plugins/reduxDevTools/index.js
+++ b/src/plugins/reduxDevTools/index.js
@@ -24,7 +24,6 @@ export const reduxDevToolsPlugin = (store, options) => {
 
           return () => {
             unsubscribe();
-            devTools.unsubscribe?.();
           }
         }, []);
       }

--- a/src/plugins/reduxDevTools/index.js
+++ b/src/plugins/reduxDevTools/index.js
@@ -1,0 +1,35 @@
+import { wrapActions } from "./wrapActions";
+import { connectDevTools } from './connectDevTools';
+
+export const reduxDevToolsPlugin = (store, options) => {
+  const devTools = connectDevTools(options);
+
+  devTools?.init(store.state);
+
+  store.plugins = {
+    hooks: [
+      ...store.plugins.hooks,
+      (React) => {
+        React.useEffect(() => {
+          if (!devTools) {
+            return;
+          }
+
+          const unsubscribe = devTools.subscribe((message) => {
+            // time traveling
+            if (message.type === 'DISPATCH' && message.payload.type === 'JUMP_TO_STATE') {
+              store.setState(JSON.parse(message.state));
+            }
+          });
+
+          return () => {
+            unsubscribe();
+            devTools.unsubscribe?.();
+          }
+        }, []);
+      }
+    ],
+  };
+
+  wrapActions(store, store.actions, devTools);
+};

--- a/src/plugins/reduxDevTools/withReduxDevTools.js
+++ b/src/plugins/reduxDevTools/withReduxDevTools.js
@@ -1,0 +1,5 @@
+export const withReduxDevTools = (key, store, originalFunction, devTools) => (...args) => {
+  originalFunction(...args);
+
+  devTools?.send(key, store.state);
+};

--- a/src/plugins/reduxDevTools/wrapActions.js
+++ b/src/plugins/reduxDevTools/wrapActions.js
@@ -1,0 +1,14 @@
+import { withReduxDevTools } from './withReduxDevTools';
+
+export const wrapActions = (store, actions, devTools) => {
+  const wrappedActions = {};
+  Object.keys(actions).forEach((key) => {
+    if (typeof actions[key] === "function") {
+      const originalFunction = actions[key];
+      actions[key] = withReduxDevTools(key, store, originalFunction, devTools);
+    }
+    if (typeof actions[key] === "object") {
+      wrappedActions[key] = wrapActions(store, actions[key]);
+    }
+  });
+};


### PR DESCRIPTION
Hello guys, just discovered your library which looks very close to something I did on my own previously. Before I discovered this approach I worked at some big product with Redux and TypeScript. There I faced thare a problem with tones of JS and TS boilerplate which such an approach helps to eliminate.

Despite Redux introduce a huge overhead, it also has a nice community and good things such as https://github.com/zalmoxisus/redux-devtools-extension. Those tools are very popular and help a lot with app debugging.

So I'd like to propose to you an integration with redux dev tools. Actually those tool has API which allows integrations with any state machine.

Those integration looks like this:
<img width="1536" alt="Screen Shot 2021-06-02 at 10 35 07 PM" src="https://user-images.githubusercontent.com/13545665/120543212-bde0e080-c3f4-11eb-97c7-22d8a37e8664.png">

and here you can see how it works:
![ezgif-1-677961cbce2e](https://user-images.githubusercontent.com/13545665/120544186-d0a7e500-c3f5-11eb-9bef-ec88cb5f4790.gif)

So what do you think?