### PR TITLE
remove React argument and use peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const actions = {
   },
 };
 
-const useGlobal = globalHook(React, initialState, actions);
+const useGlobal = globalHook(initialState, actions);
 
 const App = () => {
   const [globalState, globalActions] = useGlobal();
@@ -151,7 +151,6 @@ const actions = {
 };
 
 const useGlobal = globalHook<MyState, MyAssociatedActions>(
-  React,
   initialState,
   actions
 );

--- a/src/core/customHook.js
+++ b/src/core/customHook.js
@@ -1,14 +1,15 @@
+import * as React from 'react';
 import { newListenerEffect } from "./newListenerEffect";
 
-const getMappedActions = (store, React, mapActions) =>
+const getMappedActions = (store, mapActions) =>
   React.useMemo(
     () => (mapActions ? mapActions(store.actions) : store.actions),
     [mapActions, store.actions]
   );
 
-export function customHook(store, React, mapState, mapActions) {
+export function customHook(store, mapState, mapActions) {
   const state = mapState ? mapState(store.state) : store.state;
-  const actions = getMappedActions(store, React, mapActions);
+  const actions = getMappedActions(store, mapActions);
 
   const originalHook = React.useState(Object.create(null))[1];
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -4,13 +4,13 @@ import { customHook } from "./customHook";
 import { runListeners } from "./runListeners";
 import { setupOptions } from "./setupOptions";
 
-const useStore = (React, initialState, actions, options) => {
+const useStore = (initialState, actions, options) => {
   const store = { state: initialState, listeners: [] };
   store.setState = setState.bind(null, store);
   store.runListeners = runListeners.bind(null, store);
   store.actions = associateActions(store, actions);
   setupOptions(store, options);
-  return customHook.bind(null, store, React);
+  return customHook.bind(null, store);
 };
 
 export default useStore;


### PR DESCRIPTION
I noticed that the hook requires React instance as an argument but it is already included to `peerDependencies` in `package.json`.

So there is no need to pollute arguments and it is possible to import React directly.

**Breaking change**: remove React from hook arguments