### PR TITLE
fix double reconcilation

### DIFF
--- a/src/core/customHook.js
+++ b/src/core/customHook.js
@@ -10,9 +10,9 @@ export function customHook(store, React, mapState, mapActions) {
   const state = mapState ? mapState(store.state) : store.state;
   const actions = getMappedActions(store, React, mapActions);
 
-  const originalHook = React.useState(Object.create(null))[1];
+  const originalHook = React.useState(state)[1];
 
-  React.useEffect(newListenerEffect(store, mapState, originalHook), []); // eslint-disable-line
+  React.useEffect(newListenerEffect(store, state, mapState, originalHook), []); // eslint-disable-line
 
   return [state, actions];
 }

--- a/src/core/newListenerEffect.js
+++ b/src/core/newListenerEffect.js
@@ -1,7 +1,7 @@
 import { cleanUpListener } from "./cleanUpListener";
 
-export const newListenerEffect = (store, mapState, originalHook) => () => {
-  const newListener = { oldState: {} };
+export const newListenerEffect = (store, oldState, mapState, originalHook) => {
+  const newListener = { oldState };
   newListener.run = mapState
     ? (newState) => {
         const mappedState = mapState(newState);
@@ -11,7 +11,7 @@ export const newListenerEffect = (store, mapState, originalHook) => () => {
         }
       }
     : originalHook;
-  newListener.run(store.state);
+
   store.listeners.push(newListener);
   return cleanUpListener(store, newListener);
 };


### PR DESCRIPTION
There is a double reconcilation for every component with useGlobal hook.
It looks like this:
<img width="793" alt="Screen Shot 2021-06-03 at 12 56 27 PM" src="https://user-images.githubusercontent.com/13545665/120626613-7fd2d380-c46b-11eb-8c65-106fa52005ab.png">

**Actual result in console:**
App reconcilation 
ModuleA reconcilation 
App reconcilation 
ModuleA reconcilation 

**Expected result in console:**
App reconcilation 
ModuleA reconcilation 

Here is an example: https://codesandbox.io/s/great-mirzakhani-wntjq?file=/src/App.js:190-197

The issue was introduced by this commit 05f7b3f4314384f1cc. Those forces setState for empty react state.
But `globalHook` receives `initalState` which can be used as initial state for `React.useState`
The fix works correctly