### PR TITLE
remove redundant useMemo and afterUpdateCallback

### DIFF
--- a/src/core/customHook.js
+++ b/src/core/customHook.js
@@ -1,14 +1,8 @@
 import { newListenerEffect } from "./newListenerEffect";
 
-const getMappedActions = (store, React, mapActions) =>
-  React.useMemo(
-    () => (mapActions ? mapActions(store.actions) : store.actions),
-    [mapActions, store.actions]
-  );
-
 export function customHook(store, React, mapState, mapActions) {
   const state = mapState ? mapState(store.state) : store.state;
-  const actions = getMappedActions(store, React, mapActions);
+  const actions = mapActions ? mapActions(store.actions) : store.actions;
 
   const originalHook = React.useState(Object.create(null))[1];
 

--- a/src/core/setState.js
+++ b/src/core/setState.js
@@ -1,4 +1,5 @@
-export function setState(store, newState) {
+export function setState(store, newState, afterUpdateCallback) {
   store.state = { ...store.state, ...newState };
   store.runListeners();
+  afterUpdateCallback && afterUpdateCallback();
 }

--- a/src/core/setState.js
+++ b/src/core/setState.js
@@ -1,5 +1,4 @@
-export function setState(store, newState, afterUpdateCallback) {
+export function setState(store, newState) {
   store.state = { ...store.state, ...newState };
   store.runListeners();
-  afterUpdateCallback && afterUpdateCallback();
 }


### PR DESCRIPTION
- mapActions is js functional object; react will re-create it on each reconcilation so useMemo does nothing here; also mapActions is a straightforward O(1) function so its optimisation will cost more than direct use

- afterUpdateCallback is not used from anywhere