### PR TITLE
fix: state updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ const App = () => {
 export default App;
 ```
 
+> Note: if "useGlobal" returns an object from state then any update of the object properties will also lead to re-render for consumers of the entire object.
+
 ------------
 
 

--- a/src/core/customHook.js
+++ b/src/core/customHook.js
@@ -7,7 +7,7 @@ export function customHook(store, mapState, mapActions) {
 
   const originalHook = React.useState(state)[1];
 
-  React.useEffect(newListenerEffect(store, state, mapState, originalHook), []); // eslint-disable-line
+  React.useEffect(() => newListenerEffect(store, state, mapState, originalHook), []); // eslint-disable-line
 
   return [state, actions];
 }

--- a/src/core/newListenerEffect.js
+++ b/src/core/newListenerEffect.js
@@ -7,7 +7,7 @@ export const newListenerEffect = (store, oldState, mapState, originalHook) => {
         const mappedState = mapState(newState);
         if (mappedState !== newListener.oldState) {
           newListener.oldState = mappedState;
-          originalHook(mappedState);
+          originalHook(newState);
         }
       }
     : originalHook;


### PR DESCRIPTION
First render is broken because initial state is the entire state but on update it is only some partial value from it.

The example: https://codesandbox.io/s/fix-state-flow-tli3b?file=/src/App.js
Bugs:
1. When you will try click "+1" button you will not see changes on UI but reconcilation still happens and in console you should see new "App reconcilation " message.
On click to "+1" second and further times will work as expected.

2. Another issue is in text input of Module A. Attempts to remove last letter will fail because the hook creates useEffect new listeners on every change of 

Changes:
- replaced partial state to full state update
- eliminate duplication of effect listeners by wrap factory function
- added note to readme about re-renders for object consumers (behavior is the same for global state as well as for nested objects)