### PR TITLE
feat: add possibility to set compare function

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ const App = () => {
 export default App;
 ```
 
+> Note: if "useGlobal" returns an object from state then any update of the object properties will also lead to re-render for consumers of the entire object.
+
 ------------
 
 
@@ -79,9 +81,9 @@ Update the requests counter on every search.
 ------------
 
 
-#### [Avoid unnecessary renders](https://codesandbox.io/s/several-counters-pdbsy "CodeSandBox")
-Map a subset of the global state before use it.
-The component will only re-render if the subset is updated.
+#### [Avoid unnecessary renders](https://codesandbox.io/s/global-hook-object-optimization-rm77u "CodeSandBox")
+Use `shouldUpdate(compare)` method.
+The hook will only lead re-render if the compare callback returns true.
 
 ------------
 

--- a/src/core/customHook.js
+++ b/src/core/customHook.js
@@ -1,13 +1,23 @@
 import * as React from 'react';
 import { newListenerEffect } from "./newListenerEffect";
 
-export function customHook(store, mapState, mapActions) {
+export function customHook(store, mapState, mapActions, compare) {
   const state = mapState ? mapState(store.state) : store.state;
   const actions = mapActions ? mapActions(store.actions) : store.actions;
 
   const originalHook = React.useState(state)[1];
+  const resultObject = [state, actions];
 
-  React.useEffect(newListenerEffect(store, state, mapState, originalHook), []); // eslint-disable-line
+  let localCompare;
+  const getComparator = () => localCompare;
 
-  return [state, actions];
+  resultObject.shouldUpdate = (compare) => {
+    localCompare = compare;
+
+    return resultObject;
+  };
+
+  React.useEffect(() => newListenerEffect(store, state, mapState, originalHook, getComparator), []); // eslint-disable-line
+
+  return resultObject;
 }

--- a/src/core/newListenerEffect.js
+++ b/src/core/newListenerEffect.js
@@ -1,16 +1,24 @@
 import { cleanUpListener } from "./cleanUpListener";
 
-export const newListenerEffect = (store, oldState, mapState, originalHook) => {
+export const newListenerEffect = (store, oldState, mapState, originalHook, getComparator) => {
   const newListener = { oldState };
-  newListener.run = mapState
-    ? (newState) => {
-        const mappedState = mapState(newState);
-        if (mappedState !== newListener.oldState) {
-          newListener.oldState = mappedState;
-          originalHook(mappedState);
-        }
-      }
-    : originalHook;
+  newListener.run = (newState) => {
+    const compare = getComparator();
+
+    if (!mapState && !compare) {
+      return originalHook(newState);
+    }
+
+    const mappedState = mapState ? mapState(newState) : newState;
+    const updateNeeded = compare
+      ? compare(newListener.oldState, mappedState)
+      : mappedState !== newListener.oldState;
+
+    if (updateNeeded) {
+      newListener.oldState = mappedState;
+      originalHook(newState);
+    }
+  };
 
   store.listeners.push(newListener);
   return cleanUpListener(store, newListener);


### PR DESCRIPTION
![Screen Recording 2021-07-27 at 8 48 20 PM](https://user-images.githubusercontent.com/13545665/127205148-cc66847c-2f3f-4f9a-9736-add2af59124a.gif)

If mapState returns an object then consumers of useGlobal hook will be re-rendered on every partial update of the object.
For example with such state:
```
const state = {
  profile: {
    id: "123",
    firstName: "John",
    lastName: "Dory",
    age: 65,
    zipCode: 220019,
   // etc.
  }
}
```

and with such use case:
```
const Profile = () => {
  const [profile, actions] = useGlobal((state) => state.profile);
  // ...
};
```

The `Profile` component will re-render on change of any value in the `profile` object. For small objects this is not an issue but in real app where the `profile` would contain 20+ properties it is not handful to write 20+ hooks just to avoid re-renders. In reality  average component might use more than 1 of such objects so the hook in such case harms dev experience.

The solution is as simple as to provide one more special handler to the :
```
const Profile = () => {
  const [profile, actions] = useGlobal((state) => state.profile).shouldUpdate(
    (oldProfile, newProfile) => oldProfile.firstName !== newProfile.firstName || oldProfile.lastName !== newProfile.lastName || oldProfile.age !== newProfile.age
  );
  // ...
};
```
or using lodash:
```
const Profile = () => {
  const [profile, actions] = useGlobal((state) => state.profile).shouldUpdate(
    (oldProfile, newProfile) => !_.isMatch(newProfile, _.pick(oldProfile, 'firstName', 'lastName', 'age'))
  );
  // ...
};
```

Now, component will be re-rendered only in case if `firstName`, `lastName` or `age` will change